### PR TITLE
Fixy z piatka 1.3.2024

### DIFF
--- a/Assets/Scenes/AnimArch.unity
+++ b/Assets/Scenes/AnimArch.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.3731193, g: 0.38073996, b: 0.35872698, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -16264,7 +16264,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &444883018
 RectTransform:
   m_ObjectHideFlags: 0
@@ -54221,7 +54221,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1584388965
 RectTransform:
   m_ObjectHideFlags: 0
@@ -55536,7 +55536,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1648575867
 RectTransform:
   m_ObjectHideFlags: 0
@@ -69069,7 +69069,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &2002724229
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AnimationControl/BuiltIn/BuiltInMethodArrayIndexOf.cs
+++ b/Assets/Scripts/AnimationControl/BuiltIn/BuiltInMethodArrayIndexOf.cs
@@ -6,12 +6,12 @@ using AnimArch.Extensions;
 
 namespace Assets.Scripts.AnimationControl.BuiltIn
 {
-    public class BuiltInMethodArrayContains : BuiltInMethodArray, IReturnCollector
+    public class BuiltInMethodArrayIndexOf : BuiltInMethodArray, IReturnCollector
     {
         private EXEValueBase ReturnedValue; // Only used if .Equals method is applied
         private int CurrentlyEvaluatedIndex;
 
-        public BuiltInMethodArrayContains()
+        public BuiltInMethodArrayIndexOf()
         {
             this.ReturnedValue = null;
             this.CurrentlyEvaluatedIndex = -1;
@@ -35,7 +35,7 @@ namespace Assets.Scripts.AnimationControl.BuiltIn
                 if ((this.ReturnedValue as EXEValueBool).Value)
                 {
                     EXEExecutionResult resultB = EXEExecutionResult.Success();
-                    resultB.ReturnedOutput = this.ReturnedValue;
+                    resultB.ReturnedOutput = new EXEValueInt(this.CurrentlyEvaluatedIndex);
                     return resultB;
                 }
             }
@@ -45,7 +45,7 @@ namespace Assets.Scripts.AnimationControl.BuiltIn
             if (CurrentlyEvaluatedIndex >= owningObject.Elements.Count)
             {
                 EXEExecutionResult resultB = EXEExecutionResult.Success();
-                resultB.ReturnedOutput = new EXEValueBool(false);
+                resultB.ReturnedOutput = new EXEValueInt(-1);
                 return resultB;
             }
 
@@ -81,11 +81,17 @@ namespace Assets.Scripts.AnimationControl.BuiltIn
             // Apply '==' operator.
             else
             {
-                bool contains
-                    = owningObject.Elements
-                        .Any(element => (searchedElement.IsEqualTo(element).ReturnedOutput as EXEValueBool).Value);
+                int index = -1;
+                for (int i = 0; i < owningObject.Elements.Count; i++)
+                {
+                    if ((searchedElement.IsEqualTo(owningObject.Elements[i]).ReturnedOutput as EXEValueBool).Value)
+                    {
+                        index = i;
+                        break;
+                    }
+                }
 
-                result.ReturnedOutput = new EXEValueBool(contains);
+                result.ReturnedOutput = new EXEValueInt(index);
             }
 
             return result;

--- a/Assets/Scripts/AnimationControl/BuiltIn/BuiltInMethodArrayIndexOf.cs.meta
+++ b/Assets/Scripts/AnimationControl/BuiltIn/BuiltInMethodArrayIndexOf.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b86db4aec293e1b4d95fe0e76f9b1800
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AnimationControl/BuiltIn/BuiltInMethodBase.cs
+++ b/Assets/Scripts/AnimationControl/BuiltIn/BuiltInMethodBase.cs
@@ -1,4 +1,5 @@
 ﻿using OALProgramControl;
+using System;
 using System.Collections.Generic;
 
 namespace Assets.Scripts.AnimationControl.BuiltIn
@@ -6,5 +7,9 @@ namespace Assets.Scripts.AnimationControl.BuiltIn
     public abstract class BuiltInMethodBase
     {
         public abstract EXEExecutionResult Evaluate(EXEValueBase owningObject, List<EXEValueBase> parameters);
+        public BuiltInMethodBase Clone()
+        {
+            return (BuiltInMethodBase) Activator.CreateInstance(this.GetType());
+        }
     }
 }

--- a/Assets/Scripts/AnimationControl/EXEASTNodeIndexation.cs
+++ b/Assets/Scripts/AnimationControl/EXEASTNodeIndexation.cs
@@ -29,7 +29,7 @@ namespace OALProgramControl
             EXEValueArray evaluatedList;
             EXEValueInt evaluatedIndex;
 
-            executionResult = Index.Evaluate(currentScope, currentProgramInstance, valueContext.Clone());
+            executionResult = Index.Evaluate(currentScope, currentProgramInstance);
             if (!executionResult.IsSuccess)
             {
                 this.EvaluationState = EEvaluationState.HasBeenEvaluated;
@@ -40,7 +40,7 @@ namespace OALProgramControl
                 // Either current operand evaluation did not finish or produced an error
                 return executionResult;
             }
-
+            
             evaluatedIndex = executionResult.ReturnedOutput as EXEValueInt;
             if (evaluatedIndex == null)
             {

--- a/Assets/Scripts/AnimationControl/EXEASTNodeMethodCall.cs
+++ b/Assets/Scripts/AnimationControl/EXEASTNodeMethodCall.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace OALProgramControl
 {
-    public class EXEASTNodeMethodCall : EXEASTNodeBase
+    public class EXEASTNodeMethodCall : EXEASTNodeBase, IReturnCollector
     {
         public readonly string MethodName;
         public readonly List<EXEASTNodeBase> Arguments;
@@ -154,6 +154,14 @@ namespace OALProgramControl
         public override void Accept(Visitor v)
         {
             v.VisitExeASTNodeMethodCall(this);
+        }
+
+        public void CollectReturn(EXEValueBase returnedValue)
+        {
+            // This actually performs the assignment
+            this.EvaluationResult = EXEExecutionResult.Success();
+            this.EvaluationResult.ReturnedOutput = returnedValue;
+            this.ReturnCollected = true;
         }
     }
 }

--- a/Assets/Scripts/AnimationControl/EXECommand.cs
+++ b/Assets/Scripts/AnimationControl/EXECommand.cs
@@ -38,7 +38,7 @@ namespace OALProgramControl
             return Result;
         }
         protected abstract EXEExecutionResult Execute(OALProgram OALProgram);
-        public virtual bool CollectReturn(EXEValueBase returnedValue, OALProgram programInstance)
+        public virtual bool SubmitReturn(EXEValueBase returnedValue, OALProgram programInstance)
         {
             return false;
         }
@@ -110,6 +110,7 @@ namespace OALProgramControl
                 // It's a stack-like structure, so we enqueue the current command first, then the pending command.
                 this.CommandStack.Enqueue(this);
                 executionResult.PendingCommand.SetSuperScope(this.SuperScope);
+                executionResult.PendingCommand.CommandStack = this.CommandStack;
                 this.CommandStack.Enqueue(executionResult.PendingCommand);
                 return false;
             }

--- a/Assets/Scripts/AnimationControl/EXECommandReturn.cs
+++ b/Assets/Scripts/AnimationControl/EXECommandReturn.cs
@@ -25,7 +25,7 @@ namespace OALProgramControl
             }
 
             EXEScopeMethod owningMethodScope = GetCurrentMethodScope();
-            if (!owningMethodScope.CollectReturn(returnedExpressionEvaluationResult.ReturnedOutput, OALProgram))
+            if (!owningMethodScope.SubmitReturn(returnedExpressionEvaluationResult.ReturnedOutput, OALProgram))
             {
                 return Error("Failed to deliver return value to owning scope.", "XEC2014");
             }

--- a/Assets/Scripts/AnimationControl/EXEScopeBuiltInMethod.cs
+++ b/Assets/Scripts/AnimationControl/EXEScopeBuiltInMethod.cs
@@ -24,12 +24,12 @@ namespace OALProgramControl
                     .ToList();
 
             EXEExecutionResult result = MethodExecution.Evaluate(OwningObject, parameters);
-            if (!HandleSingleShotASTEvaluation(result))
+            if (!HandleRepeatableASTEvaluation(result))
             {
                 return result;
             }
 
-            if (!this.CollectReturn(result.ReturnedOutput, OALProgram))
+            if (!this.SubmitReturn(result.ReturnedOutput, OALProgram))
             {
                 return Error("Failed to deliver return value to owning scope.", "XEC2044");
             }
@@ -44,7 +44,7 @@ namespace OALProgramControl
 
         protected override EXEScope CreateDuplicateScope()
         {
-            return new EXEScopeBuiltInMethod(this.MethodDefinition, this.MethodExecution);
+            return new EXEScopeBuiltInMethod(this.MethodDefinition, this.MethodExecution.Clone()); ;
         }
     }
 }

--- a/Assets/Scripts/AnimationControl/EXEScopeForEach.cs
+++ b/Assets/Scripts/AnimationControl/EXEScopeForEach.cs
@@ -66,6 +66,8 @@ namespace OALProgramControl
                     this.Iterable.Accept(visitor);
                     return Error
                     (
+
+                        "XEC2029",
                         string.Format
                         (
                             "At iterable index {0}: Iterable elements are of types: {1}. {2}",
@@ -78,8 +80,7 @@ namespace OALProgramControl
                                 this.IteratorName,
                                 iteratorVariable.Value.TypeName
                             )
-                        ),
-                        "XEC2029"
+                        )
                     );
                 }
             }

--- a/Assets/Scripts/AnimationControl/EXEScopeMethod.cs
+++ b/Assets/Scripts/AnimationControl/EXEScopeMethod.cs
@@ -7,7 +7,7 @@ namespace OALProgramControl
     public class EXEScopeMethod : EXEScope
     {
         public CDMethod MethodDefinition;
-        public EXEASTNodeMethodCall MethodCallOrigin;
+        public IReturnCollector MethodCallOrigin;
         public EXEValueBase OwningObject;
 
         public EXEScopeMethod() : this(null)
@@ -19,7 +19,7 @@ namespace OALProgramControl
             this.MethodCallOrigin = null;
             this.OwningObject = null;
         }
-        public override bool CollectReturn(EXEValueBase returnedValue, OALProgram programInstance)
+        public override bool SubmitReturn(EXEValueBase returnedValue, OALProgram programInstance)
         {
             // Check compatibility of types
             if (!EXETypes.CanBeAssignedTo(returnedValue, this.MethodDefinition.ReturnType, programInstance.ExecutionSpace))
@@ -31,9 +31,7 @@ namespace OALProgramControl
             if (MethodCallOrigin != null)
             {
                 // This actually performs the assignment
-                this.MethodCallOrigin.EvaluationResult = Success();
-                this.MethodCallOrigin.EvaluationResult.ReturnedOutput = returnedValue;
-                this.MethodCallOrigin.ReturnCollected = true;
+                this.MethodCallOrigin.CollectReturn(returnedValue);
             }
 
             return true;

--- a/Assets/Scripts/AnimationControl/EXEValueArray.cs
+++ b/Assets/Scripts/AnimationControl/EXEValueArray.cs
@@ -295,6 +295,7 @@ namespace OALProgramControl
             DefiningClass = new CDClass("Array", null);
 
             InitializeContainsMethod();
+            InitializeIndexOfMethod();
             InitializeCountMethod();
         }
 
@@ -310,6 +311,20 @@ namespace OALProgramControl
                 }
             );
             MethodContains.ExecutableCode = new EXEScopeBuiltInMethod(MethodContains, new BuiltInMethodArrayContains());
+            DefiningClass.AddMethod(MethodContains);
+        }
+        private void InitializeIndexOfMethod()
+        {
+            CDMethod MethodContains = new CDMethod(DefiningClass, "IndexOf", EXETypes.IntegerTypeName);
+            MethodContains.Parameters.Add
+            (
+                new CDParameter()
+                {
+                    Name = "element",
+                    Type = EXETypes.WildCardTypeName
+                }
+            );
+            MethodContains.ExecutableCode = new EXEScopeBuiltInMethod(MethodContains, new BuiltInMethodArrayIndexOf());
             DefiningClass.AddMethod(MethodContains);
         }
         private void InitializeCountMethod()

--- a/Assets/Scripts/AnimationControl/EXEValueReference.cs
+++ b/Assets/Scripts/AnimationControl/EXEValueReference.cs
@@ -23,9 +23,8 @@ namespace OALProgramControl
         }
         public EXEValueReference(CDClassInstance classInstance)
         {
-            this.ClassInstance = null;
-            this.TypeClass = classInstance.OwningClass;
             this.ClassInstance = classInstance;
+            this.TypeClass = classInstance.OwningClass;
         }
         public EXEValueReference(EXEValueReference original)
         {
@@ -121,6 +120,7 @@ namespace OALProgramControl
         private void CopyValues(EXEValueReference source, EXEValueReference target)
         {
             target.ClassInstance = source.ClassInstance;
+            target.TypeClass = source.TypeClass;
         }
         public override EXEExecutionResult ApplyOperator(string operation)
         {

--- a/Assets/Scripts/AnimationControl/IReturnCollector.cs
+++ b/Assets/Scripts/AnimationControl/IReturnCollector.cs
@@ -1,0 +1,10 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace OALProgramControl
+{
+    public interface IReturnCollector
+    {
+        void CollectReturn(EXEValueBase returnedValue);
+    }
+}

--- a/Assets/Scripts/AnimationControl/IReturnCollector.cs.meta
+++ b/Assets/Scripts/AnimationControl/IReturnCollector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b49aa032b2d20054d88fbfcf85ffbf48
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UnitTests/AnimationControl/EXECommandArrayMethodTests.cs
+++ b/Assets/UnitTests/AnimationControl/EXECommandArrayMethodTests.cs
@@ -277,6 +277,446 @@ namespace Assets.UnitTests.AnimationControl
             }
         }
 
+        [TestFixture]
+        public class Contains_Object : StandardTest
+        {
+            [Test]
+            public void HappyDay_01_DoesNotOverrideEquals_01_IdenticalObjectContained()
+            {
+                CommandTest Test = new CommandTest();
+
+                // Arrange
+                string _methodSourceCode = "create object instance x1 of Class1;\nx1.Attribute1 = \"a\";\ncreate object instance x2 of Class1;\nx2.Attribute1 = \"b\";\ncreate list y of Class1 {x1, x2};z = y.Contains(x2);";
+
+                OALProgram programInstance = new OALProgram();
+                CDClass owningClass = programInstance.ExecutionSpace.SpawnClass("Class1");
+
+                CDMethod owningMethod = new CDMethod(owningClass, "Method1", "");
+                owningClass.AddMethod(owningMethod);
+
+                CDAttribute attr = new CDAttribute("Attribute1", EXETypes.StringTypeName);
+                owningClass.AddAttribute(attr);
+
+                // Act
+                EXEScopeMethod methodScope = OALParserBridge.Parse(_methodSourceCode);
+                owningMethod.ExecutableCode = methodScope;
+                programInstance.SuperScope = methodScope;
+
+                EXEExecutionResult _executionResult = PerformExecution(programInstance);
+
+                // Assert
+                Test.Declare(methodScope, _executionResult);
+
+                CDClassInstance x1Instance = owningClass.Instances[^2];
+                CDClassInstance x2Instance = owningClass.Instances[^1];
+
+                Test.Variables
+                        .ExpectVariable("x1", new EXEValueReference(x1Instance))
+                        .ExpectVariable("x2", new EXEValueReference(x2Instance))
+                        .ExpectVariable
+                        (
+                            "y",
+                            new EXEValueArray("Class1[]")
+                            {
+                                Elements = new List<EXEValueBase>()
+                                {
+                                    new EXEValueReference(x1Instance),
+                                    new EXEValueReference(x2Instance)
+                                }
+                            }
+                        )
+                        .ExpectVariable("z", new EXEValueBool(true))
+                        .ExpectVariable("self", methodScope.OwningObject);
+
+                Test.PerformAssertion();
+            }
+            
+            [Test]
+            public void HappyDay_01_DoesNotOverrideEquals_02_IdenticalObjectNotContained()
+            {
+                CommandTest Test = new CommandTest();
+
+                // Arrange
+                string _methodSourceCode = "create object instance x1 of Class1;\nx1.Attribute1 = \"a\";\ncreate object instance x2 of Class1;\nx2.Attribute1 = \"b\";\ncreate list y of Class1 {x1};z = y.Contains(x2);";
+
+                OALProgram programInstance = new OALProgram();
+                CDClass owningClass = programInstance.ExecutionSpace.SpawnClass("Class1");
+
+                CDMethod owningMethod = new CDMethod(owningClass, "Method1", "");
+                owningClass.AddMethod(owningMethod);
+
+                CDAttribute attr = new CDAttribute("Attribute1", EXETypes.StringTypeName);
+                owningClass.AddAttribute(attr);
+
+                // Act
+                EXEScopeMethod methodScope = OALParserBridge.Parse(_methodSourceCode);
+                owningMethod.ExecutableCode = methodScope;
+                programInstance.SuperScope = methodScope;
+
+                EXEExecutionResult _executionResult = PerformExecution(programInstance);
+
+                // Assert
+                Test.Declare(methodScope, _executionResult);
+
+                CDClassInstance x1Instance = owningClass.Instances[^2];
+                CDClassInstance x2Instance = owningClass.Instances[^1];
+
+                Test.Variables
+                        .ExpectVariable("x1", new EXEValueReference(x1Instance))
+                        .ExpectVariable("x2", new EXEValueReference(x2Instance))
+                        .ExpectVariable
+                        (
+                            "y",
+                            new EXEValueArray("Class1[]")
+                            {
+                                Elements = new List<EXEValueBase>()
+                                {
+                                    new EXEValueReference(x1Instance)
+                                }
+                            }
+                        )
+                        .ExpectVariable("z", new EXEValueBool(false))
+                        .ExpectVariable("self", methodScope.OwningObject);
+
+                Test.PerformAssertion();
+            }
+
+            [Test]
+            public void HappyDay_02_OverridesEquals_01_IdenticalObjectContained()
+            {
+                CommandTest Test = new CommandTest();
+
+                // Arrange
+                string _methodSourceCode = "create object instance x1 of Class1;\nx1.Attribute1 = \"a\";\ncreate object instance x2 of Class1;\nx2.Attribute1 = \"a\";\ncreate list y of Class1 {x1};z = y.Contains(x2);";
+
+                OALProgram programInstance = new OALProgram();
+                CDClass owningClass = programInstance.ExecutionSpace.SpawnClass("Class1");
+
+                CDMethod owningMethod = new CDMethod(owningClass, "Method1", "");
+                owningClass.AddMethod(owningMethod);
+
+                CDAttribute attr = new CDAttribute("Attribute1", EXETypes.StringTypeName);
+                owningClass.AddAttribute(attr);
+
+                string _equalsMethodSourceCode = "return self.Attribute1 == obj.Attribute1;";
+                CDMethod equalsMethod = new CDMethod(owningClass, "Equals", EXETypes.BooleanTypeName);
+                equalsMethod.Parameters.Add(new CDParameter() { Name = "obj", Type = "Class1"});
+                owningClass.AddMethod(equalsMethod);
+
+                // Act
+                EXEScopeMethod methodScope = OALParserBridge.Parse(_methodSourceCode);
+                owningMethod.ExecutableCode = methodScope;
+                programInstance.SuperScope = methodScope;
+
+                equalsMethod.ExecutableCode = OALParserBridge.Parse(_equalsMethodSourceCode);
+
+                EXEExecutionResult _executionResult = PerformExecution(programInstance);
+
+                // Assert
+                Test.Declare(methodScope, _executionResult);
+
+                CDClassInstance x1Instance = owningClass.Instances[^2];
+                CDClassInstance x2Instance = owningClass.Instances[^1];
+
+                Test.Variables
+                        .ExpectVariable("x1", new EXEValueReference(x1Instance))
+                        .ExpectVariable("x2", new EXEValueReference(x2Instance))
+                        .ExpectVariable
+                        (
+                            "y",
+                            new EXEValueArray("Class1[]")
+                            {
+                                Elements = new List<EXEValueBase>()
+                                {
+                                    new EXEValueReference(x1Instance)
+                                }
+                            }
+                        )
+                        .ExpectVariable("z", new EXEValueBool(true))
+                        .ExpectVariable("self", methodScope.OwningObject);
+
+                Test.PerformAssertion();
+            }
+
+            [Test]
+            public void HappyDay_02_OverridesEquals_02_IdenticalObjectNotContained()
+            {
+                CommandTest Test = new CommandTest();
+
+                // Arrange
+                string _methodSourceCode = "create object instance x1 of Class1;\nx1.Attribute1 = \"a\";\ncreate object instance x2 of Class1;\nx2.Attribute1 = \"b\";\ncreate list y of Class1 {x1};z = y.Contains(x2);";
+
+                OALProgram programInstance = new OALProgram();
+                CDClass owningClass = programInstance.ExecutionSpace.SpawnClass("Class1");
+
+                CDMethod owningMethod = new CDMethod(owningClass, "Method1", "");
+                owningClass.AddMethod(owningMethod);
+
+                CDAttribute attr = new CDAttribute("Attribute1", EXETypes.StringTypeName);
+                owningClass.AddAttribute(attr);
+
+                string _equalsMethodSourceCode = "return self.Attribute1 == obj.Attribute1;";
+                CDMethod equalsMethod = new CDMethod(owningClass, "Equals", EXETypes.BooleanTypeName);
+                equalsMethod.Parameters.Add(new CDParameter() { Name = "obj", Type = "Class1" });
+                owningClass.AddMethod(equalsMethod);
+
+                // Act
+                EXEScopeMethod methodScope = OALParserBridge.Parse(_methodSourceCode);
+                owningMethod.ExecutableCode = methodScope;
+                programInstance.SuperScope = methodScope;
+
+                equalsMethod.ExecutableCode = OALParserBridge.Parse(_equalsMethodSourceCode);
+
+                EXEExecutionResult _executionResult = PerformExecution(programInstance);
+
+                // Assert
+                Test.Declare(methodScope, _executionResult);
+
+                CDClassInstance x1Instance = owningClass.Instances[^2];
+                CDClassInstance x2Instance = owningClass.Instances[^1];
+
+                Test.Variables
+                        .ExpectVariable("x1", new EXEValueReference(x1Instance))
+                        .ExpectVariable("x2", new EXEValueReference(x2Instance))
+                        .ExpectVariable
+                        (
+                            "y",
+                            new EXEValueArray("Class1[]")
+                            {
+                                Elements = new List<EXEValueBase>()
+                                {
+                                    new EXEValueReference(x1Instance)
+                                }
+                            }
+                        )
+                        .ExpectVariable("z", new EXEValueBool(false))
+                        .ExpectVariable("self", methodScope.OwningObject);
+
+                Test.PerformAssertion();
+            }
+        }
+
+
+
+        [TestFixture]
+        public class IndexOf_Object : StandardTest
+        {
+            [Test]
+            public void HappyDay_01_DoesNotOverrideEquals_01_IdenticalObjectContained()
+            {
+                CommandTest Test = new CommandTest();
+
+                // Arrange
+                string _methodSourceCode = "create object instance x1 of Class1;\nx1.Attribute1 = \"a\";\ncreate object instance x2 of Class1;\nx2.Attribute1 = \"b\";\ncreate list y of Class1 {x1, x2};z = y.IndexOf(x2);";
+
+                OALProgram programInstance = new OALProgram();
+                CDClass owningClass = programInstance.ExecutionSpace.SpawnClass("Class1");
+
+                CDMethod owningMethod = new CDMethod(owningClass, "Method1", "");
+                owningClass.AddMethod(owningMethod);
+
+                CDAttribute attr = new CDAttribute("Attribute1", EXETypes.StringTypeName);
+                owningClass.AddAttribute(attr);
+
+                // Act
+                EXEScopeMethod methodScope = OALParserBridge.Parse(_methodSourceCode);
+                owningMethod.ExecutableCode = methodScope;
+                programInstance.SuperScope = methodScope;
+
+                EXEExecutionResult _executionResult = PerformExecution(programInstance);
+
+                // Assert
+                Test.Declare(methodScope, _executionResult);
+
+                CDClassInstance x1Instance = owningClass.Instances[^2];
+                CDClassInstance x2Instance = owningClass.Instances[^1];
+
+                Test.Variables
+                        .ExpectVariable("x1", new EXEValueReference(x1Instance))
+                        .ExpectVariable("x2", new EXEValueReference(x2Instance))
+                        .ExpectVariable
+                        (
+                            "y",
+                            new EXEValueArray("Class1[]")
+                            {
+                                Elements = new List<EXEValueBase>()
+                                {
+                                    new EXEValueReference(x1Instance),
+                                    new EXEValueReference(x2Instance)
+                                }
+                            }
+                        )
+                        .ExpectVariable("z", new EXEValueInt(1))
+                        .ExpectVariable("self", methodScope.OwningObject);
+
+                Test.PerformAssertion();
+            }
+
+            [Test]
+            public void HappyDay_01_DoesNotOverrideEquals_02_IdenticalObjectNotContained()
+            {
+                CommandTest Test = new CommandTest();
+
+                // Arrange
+                string _methodSourceCode = "create object instance x1 of Class1;\nx1.Attribute1 = \"a\";\ncreate object instance x2 of Class1;\nx2.Attribute1 = \"b\";\ncreate list y of Class1 {x1};z = y.IndexOf(x2);";
+
+                OALProgram programInstance = new OALProgram();
+                CDClass owningClass = programInstance.ExecutionSpace.SpawnClass("Class1");
+
+                CDMethod owningMethod = new CDMethod(owningClass, "Method1", "");
+                owningClass.AddMethod(owningMethod);
+
+                CDAttribute attr = new CDAttribute("Attribute1", EXETypes.StringTypeName);
+                owningClass.AddAttribute(attr);
+
+                // Act
+                EXEScopeMethod methodScope = OALParserBridge.Parse(_methodSourceCode);
+                owningMethod.ExecutableCode = methodScope;
+                programInstance.SuperScope = methodScope;
+
+                EXEExecutionResult _executionResult = PerformExecution(programInstance);
+
+                // Assert
+                Test.Declare(methodScope, _executionResult);
+
+                CDClassInstance x1Instance = owningClass.Instances[^2];
+                CDClassInstance x2Instance = owningClass.Instances[^1];
+
+                Test.Variables
+                        .ExpectVariable("x1", new EXEValueReference(x1Instance))
+                        .ExpectVariable("x2", new EXEValueReference(x2Instance))
+                        .ExpectVariable
+                        (
+                            "y",
+                            new EXEValueArray("Class1[]")
+                            {
+                                Elements = new List<EXEValueBase>()
+                                {
+                                    new EXEValueReference(x1Instance)
+                                }
+                            }
+                        )
+                        .ExpectVariable("z", new EXEValueInt(-1))
+                        .ExpectVariable("self", methodScope.OwningObject);
+
+                Test.PerformAssertion();
+            }
+
+            [Test]
+            public void HappyDay_02_OverridesEquals_01_IdenticalObjectContained()
+            {
+                CommandTest Test = new CommandTest();
+
+                // Arrange
+                string _methodSourceCode = "create object instance x1 of Class1;\nx1.Attribute1 = \"a\";\ncreate object instance x2 of Class1;\nx2.Attribute1 = \"a\";\ncreate list y of Class1 {x1};z = y.IndexOf(x2);";
+
+                OALProgram programInstance = new OALProgram();
+                CDClass owningClass = programInstance.ExecutionSpace.SpawnClass("Class1");
+
+                CDMethod owningMethod = new CDMethod(owningClass, "Method1", "");
+                owningClass.AddMethod(owningMethod);
+
+                CDAttribute attr = new CDAttribute("Attribute1", EXETypes.StringTypeName);
+                owningClass.AddAttribute(attr);
+
+                string _equalsMethodSourceCode = "return self.Attribute1 == obj.Attribute1;";
+                CDMethod equalsMethod = new CDMethod(owningClass, "Equals", EXETypes.BooleanTypeName);
+                equalsMethod.Parameters.Add(new CDParameter() { Name = "obj", Type = "Class1" });
+                owningClass.AddMethod(equalsMethod);
+
+                // Act
+                EXEScopeMethod methodScope = OALParserBridge.Parse(_methodSourceCode);
+                owningMethod.ExecutableCode = methodScope;
+                programInstance.SuperScope = methodScope;
+
+                equalsMethod.ExecutableCode = OALParserBridge.Parse(_equalsMethodSourceCode);
+
+                EXEExecutionResult _executionResult = PerformExecution(programInstance);
+
+                // Assert
+                Test.Declare(methodScope, _executionResult);
+
+                CDClassInstance x1Instance = owningClass.Instances[^2];
+                CDClassInstance x2Instance = owningClass.Instances[^1];
+
+                Test.Variables
+                        .ExpectVariable("x1", new EXEValueReference(x1Instance))
+                        .ExpectVariable("x2", new EXEValueReference(x2Instance))
+                        .ExpectVariable
+                        (
+                            "y",
+                            new EXEValueArray("Class1[]")
+                            {
+                                Elements = new List<EXEValueBase>()
+                                {
+                                    new EXEValueReference(x1Instance)
+                                }
+                            }
+                        )
+                        .ExpectVariable("z", new EXEValueInt(0))
+                        .ExpectVariable("self", methodScope.OwningObject);
+
+                Test.PerformAssertion();
+            }
+
+            [Test]
+            public void HappyDay_02_OverridesEquals_02_IdenticalObjectNotContained()
+            {
+                CommandTest Test = new CommandTest();
+
+                // Arrange
+                string _methodSourceCode = "create object instance x1 of Class1;\nx1.Attribute1 = \"a\";\ncreate object instance x2 of Class1;\nx2.Attribute1 = \"b\";\ncreate list y of Class1 {x1};z = y.IndexOf(x2);";
+
+                OALProgram programInstance = new OALProgram();
+                CDClass owningClass = programInstance.ExecutionSpace.SpawnClass("Class1");
+
+                CDMethod owningMethod = new CDMethod(owningClass, "Method1", "");
+                owningClass.AddMethod(owningMethod);
+
+                CDAttribute attr = new CDAttribute("Attribute1", EXETypes.StringTypeName);
+                owningClass.AddAttribute(attr);
+
+                string _equalsMethodSourceCode = "return self.Attribute1 == obj.Attribute1;";
+                CDMethod equalsMethod = new CDMethod(owningClass, "Equals", EXETypes.BooleanTypeName);
+                equalsMethod.Parameters.Add(new CDParameter() { Name = "obj", Type = "Class1" });
+                owningClass.AddMethod(equalsMethod);
+
+                // Act
+                EXEScopeMethod methodScope = OALParserBridge.Parse(_methodSourceCode);
+                owningMethod.ExecutableCode = methodScope;
+                programInstance.SuperScope = methodScope;
+
+                equalsMethod.ExecutableCode = OALParserBridge.Parse(_equalsMethodSourceCode);
+
+                EXEExecutionResult _executionResult = PerformExecution(programInstance);
+
+                // Assert
+                Test.Declare(methodScope, _executionResult);
+
+                CDClassInstance x1Instance = owningClass.Instances[^2];
+                CDClassInstance x2Instance = owningClass.Instances[^1];
+
+                Test.Variables
+                        .ExpectVariable("x1", new EXEValueReference(x1Instance))
+                        .ExpectVariable("x2", new EXEValueReference(x2Instance))
+                        .ExpectVariable
+                        (
+                            "y",
+                            new EXEValueArray("Class1[]")
+                            {
+                                Elements = new List<EXEValueBase>()
+                                {
+                                    new EXEValueReference(x1Instance)
+                                }
+                            }
+                        )
+                        .ExpectVariable("z", new EXEValueInt(-1))
+                        .ExpectVariable("self", methodScope.OwningObject);
+
+                Test.PerformAssertion();
+            }
+        }
+
 
         [TestFixture]
         public class Count_string : StandardTest

--- a/Assets/UnitTests/AnimationControl/VariableAsserter.cs
+++ b/Assets/UnitTests/AnimationControl/VariableAsserter.cs
@@ -98,7 +98,12 @@ namespace Assets.UnitTests.AnimationControl
                         }
                         else
                         {
-
+                            Assert.AreEqual
+                            (
+                                (expectedVariable.Value as EXEValueReference).ClassInstance.UniqueID,
+                                (actualVariable.Value as EXEValueReference).ClassInstance.UniqueID,
+                                string.Format("The expected variable '{0}' references instance with ID '{1}'. It should reference '{2}'.", expectedVariable.Name, (actualVariable.Value as EXEValueReference).ClassInstance.UniqueID, (expectedVariable.Value as EXEValueReference).ClassInstance.UniqueID)
+                            );
                         }
                     }
                 );


### PR DESCRIPTION
indexacia atributov, IndexOf metoda, IndexOf a Contains mozu pouzivat Equals metodu (jej parameter nech sa vola 'obj' a je rovnakeho typu ako vlastniaca trieda), methoda v CD editore moze mat navratovy typ pole